### PR TITLE
remove comments before sending vue options to constructor.

### DIFF
--- a/src/utils/compiler.js
+++ b/src/utils/compiler.js
@@ -17,7 +17,8 @@ export default function ({ template, script = '{}', styles }) {
     if (typeof Babel !== 'undefined') {
       script = Babel.transform(script, { // eslint-disable-line
         presets: [['es2015', { 'loose': true, 'modules': false }], 'stage-2'],
-        plugins: ['transform-vue-jsx']
+        plugins: ['transform-vue-jsx'],
+        comments: false
       }).code
     }
 


### PR DESCRIPTION
When I try to migrate my work on this, the comment before the code crash vuep.

```jsx
/* vuep */
export default {
  render (h) {
    return (
      <surface width={100} height={100}>
        <layer>
          <curve
            fill="none"
            stroke="blue"
            points={[{x:0, y:2}, {x: 20, y: 10}, {x: 50, y: 40}]}/>
        </layer>
      </surface>
    )
  }
}
```

