### PR TITLE
make vuep dynamic created components appear in devtools

### DIFF
--- a/src/components/preview.js
+++ b/src/components/preview.js
@@ -38,6 +38,7 @@ export default {
       this.$el.appendChild(this.codeEl)
 
       try {
+        val.parent = this
         this.codeVM = new Vue(val).$mount(this.codeEl)
       } catch (e) {
         /* istanbul ignore next */


### PR DESCRIPTION
hi, I use it as a dev tool locally, and I find the dynamic mounted component debug in devtool useful.

however, devtools can only show component who is mounted on root components.

https://vuejs.org/v2/api/#parent

http://stackoverflow.com/questions/38307070/why-dynamically-mounted-vuejs-content-is-not-child-component-of-root-vue-instanc