### PR TITLE
Remove redundant `h`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -293,7 +293,7 @@ Sure.
         count: 0
       }
     },
-    render (h) {
+    render () {
       return (
         <div style={{ color: 'red' }}> { this.count } </div>
       )
@@ -311,7 +311,7 @@ vuep implement a nodejs like synchrounous require interface in browser, so you c
 /* remote.js */
 export default {
   name: 'remote',
-  render (h) {
+  render () {
     return <div>from remote</div>
   }
 }

--- a/docs/remote.js
+++ b/docs/remote.js
@@ -1,6 +1,6 @@
 export default {
   name: 'remote',
-  render (h) {
+  render () {
     return <div>from remote</div>
   }
 }

--- a/remote.js
+++ b/remote.js
@@ -1,6 +1,6 @@
 export default {
   name: 'remote',
-  render (h) {
+  render () {
     return <div>from remote</div>
   }
 }


### PR DESCRIPTION
Since [babel-plugin-transform-vue-jsx@3.4.0](https://github.com/vuejs/babel-plugin-transform-vue-jsx#h-auto-injection) `h` is automatically injected into methods with JSX so it can be removed.